### PR TITLE
fix: getTranslation hook doesn't read namespace for Metadata

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,8 +1,7 @@
 {
-  "Metadata": {
-    "title": "MABP Brand Website EN",
-    "description": "Best Brand Website in the world!"
-  },
+  "title": "MABP Brand Website EN",
+  "description": "Best Brand Website in the world!",
+
   "Index": {
     "title": "Hello world!"
   }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,8 +1,7 @@
 {
-  "Metadata": {
-    "title": "MABP Brand Website ES",
-    "description": "Mejor Brand Website en le mundo!"
-  },
+  "title": "MABP Brand Website ES",
+  "description": "Mejor Brand Website en le mundo!",
+
   "Index": {
     "title": "Hola mundo!"
   }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,8 +1,7 @@
 {
-  "Metadata": {
-    "title": "Site Web de Marque MABP FR",
-    "description": "Meilleur site web de marque d'entreprise dans le monde!"
-  },
+  "title": "Site Web de Marque MABP FR",
+  "description": "Meilleur site web de marque d'entreprise dans le monde!",
+
   "Index": {
     "title": "Bonjour, le monde!"
   }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,10 +6,9 @@ export async function generateMetadata({
 }: {
   params: { locale: string };
 }) {
-  const t = await getTranslations({ locale, namespace: 'Metadata' });
+  const t = await getTranslations({ locale });
 
   return {
-    // Here we can see that it doesn't found the keys, but these already exists and are working on the browser properly.
     title: t('title'),
     description: t('description'),
   };


### PR DESCRIPTION
This PR was created in order to use correctly the getTranslations hook. At the start with yarn, seems to be working with the nameSpace prop to point to Metadata objects in the translations. Using Bum seems to not work at all on the code editor (but yes on the browser). 

In any case, I've deleted the object and logic. Working still as expected.